### PR TITLE
修正文件读取失败的判断方式

### DIFF
--- a/src/font_fnt.c
+++ b/src/font_fnt.c
@@ -406,7 +406,7 @@ rt_inline int readbyte(int fd, unsigned char *cp)
 {
     unsigned char buf[1];
 
-    if (read(fd, buf, 1) != 1)
+    if (read(fd, buf, 1) == -1)
         return 0;
     *cp = buf[0];
     return 1;

--- a/src/image_bmp.c
+++ b/src/image_bmp.c
@@ -94,7 +94,7 @@ static rt_bool_t rtgui_image_bmp_check(struct rtgui_filerw *file)
         {
             break;
         }
-        if (rtgui_filerw_read(file, (void *)buffer, 18, 1) != 1)
+        if (rtgui_filerw_read(file, (void *)buffer, 18, 1) == -1)
         {
             break;
         }
@@ -108,7 +108,7 @@ static rt_bool_t rtgui_image_bmp_check(struct rtgui_filerw *file)
         if (*(rt_uint32_t *)&buffer[14] == 12)
         {
             /* Bitmap Header Version 2.x */
-            if (rtgui_filerw_read(file, (void *)buffer, 8, 1) != 1)
+            if (rtgui_filerw_read(file, (void *)buffer, 8, 1) == -1)
             {
                 break;
             }
@@ -118,7 +118,7 @@ static rt_bool_t rtgui_image_bmp_check(struct rtgui_filerw *file)
         else
         {
             /* Bitmap Header Version bigger than 2.x */
-            if (rtgui_filerw_read(file, (void *)buffer, 8, 1) != 1)
+            if (rtgui_filerw_read(file, (void *)buffer, 8, 1) == -1)
             {
                 break;
             }
@@ -210,7 +210,7 @@ static rt_bool_t rtgui_image_bmp_load(struct rtgui_image *image, struct rtgui_fi
         {
             break;
         }
-        if (rtgui_filerw_read(file, (void *)wrkBuffer, 18, 1) != 1)
+        if (rtgui_filerw_read(file, (void *)wrkBuffer, 18, 1) == -1)
         {
             break;
         }
@@ -227,7 +227,7 @@ static rt_bool_t rtgui_image_bmp_load(struct rtgui_image *image, struct rtgui_fi
         if (bmpHeaderSize == 12)
         {
             /* Bitmap Header Version 2.x */
-            if (rtgui_filerw_read(file, (void *)wrkBuffer, 8, 1) != 1)
+            if (rtgui_filerw_read(file, (void *)wrkBuffer, 8, 1) == -1)
             {
                 break;
             }
@@ -242,7 +242,7 @@ static rt_bool_t rtgui_image_bmp_load(struct rtgui_image *image, struct rtgui_fi
             /* Bitmap Header Version bigger than 2.x */
             rt_uint32_t compression;
 
-            if (rtgui_filerw_read(file, (void *)wrkBuffer, 36, 1) != 1)
+            if (rtgui_filerw_read(file, (void *)wrkBuffer, 36, 1) == -1)
             {
                 break;
             }


### PR DESCRIPTION
RTT的DFS文件系统中的read函数使用读取到的字符数量作为返回值，错误时返回-1，此问题导致bmp文件无法读取，请审阅